### PR TITLE
Fiftyone docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,37 +41,11 @@ Operating rooms (ORs) demand precise coordination among surgeons, nurses, and eq
 
 ## EgoExOR Dataset
 
-The **EgoExOR** dataset is hosted on [Hugging Face](https://huggingface.co/datasets/ardamamur/EgoExOR). It provides a rich collection of multimodal simulated surgical procedure data, including synchronized RGB video, audio, eye-gaze, hand-tracking, 3D point clouds, and scene-graph annotations. For detailed information on dataset structure, modalities, and usage instructions, please refer to the comprehensive guidelines in [`data/README.md`](data/README.md).
+The **EgoExOR** dataset is hosted on [Hugging Face](https://huggingface.co/datasets/ardamamur/EgoExOR). It provides a rich collection of multimodal simulated surgical procedure data, including synchronized RGB video, audio, eye gaze, hand tracking, 3D point clouds, and scene graph annotations.
 
-### Explore with FiftyOne
-[explore_with_fiftyone.webm](https://github.com/user-attachments/assets/3dbdd5be-5fa3-4fbf-a945-f65806bb0136)
+Detailed information about the dataset structure, modalities, storage format, and usage instructions can be found in the comprehensive documentation at [`data/README.md`](data/README.md).
+In addition to the provided Python utilities, EgoExOR can **optionally** be visualized and explored using external visualization tools for interactive inspection and qualitative analysis. This can be useful for browsing synchronized modalities, inspecting annotations, and debugging data pipelines. Further details on visualization and supported tools are also documented in [`data/README.md`](data/README.md).
 
-You can interactively explore EgoExOR using [FiftyOne](https://docs.voxel51.com/):
-
-```bash
-pip install fiftyone h5py huggingface-hub
-```
-
-```python
-import fiftyone as fo
-import fiftyone.zoo as foz
-
-# Load dataset (downloads miss_4.h5 by default)
-dataset = foz.load_zoo_dataset(
-    "https://github.com/AdonaiVera/EgoExOR",
-    max_samples=100,
-)
-
-# Launch the FiftyOne App
-fo.launch_app(dataset)
-```
-
-The FiftyOne loader supports multiple options:
-- **Specific files**: `h5_files=["miss_1.h5", "ultrasound_1.h5"]`
-- **Local files**: `h5_path="/path/to/egoexor.h5"`
-- **Full dataset**: `download_full=True` (requires ~100GB)
-
-All modalities are loaded as grouped samples with synchronized views from egocentric cameras (head_surgeon, assistant, circulator, anesthetist), exocentric cameras, and 3D point clouds.
 
 ## Scene Graph Generation
 This part of the repository contains the code for training and evaluating scene graph generation models.

--- a/data/README.md
+++ b/data/README.md
@@ -10,43 +10,6 @@ The EgoExOR dataset provides a comprehensive, multimodal view of simulated surgi
 
 * **Research Applicability**: EgoExOR aims to fill the gap in both egocentric and exocentric surgrical datasets, supporting development of AI assistants, skill assessment tools, and multimodal models in medical and augmented reality domains.
 
-## 🚀 Quick Start with FiftyOne
-
-[explore_with_fiftyone.webm](https://github.com/user-attachments/assets/3dbdd5be-5fa3-4fbf-a945-f65806bb0136)
-
-```bash
-pip install fiftyone h5py huggingface-hub
-```
-
-```python
-import fiftyone as fo
-import fiftyone.zoo as foz
-
-# Option 1: Download specific files from HuggingFace (default: miss_4.h5)
-dataset = foz.load_zoo_dataset(
-    "https://github.com/AdonaiVera/EgoExOR",
-    max_samples=100,
-    h5_files=["miss_4.h5"],  # Options: miss_1-4.h5, ultrasound_1-4.h5, ultrasound_5_14.h5, ultrasound_5_58.h5
-)
-
-# Option 2: Use local h5 file or directory
-dataset = foz.load_zoo_dataset(
-    "https://github.com/AdonaiVera/EgoExOR",
-    max_samples=100,
-    h5_path="/path/to/miss_4.h5",  # Single file or directory with .h5 files
-)
-
-# Option 3: Download full dataset and merge (~100GB required)
-dataset = foz.load_zoo_dataset(
-    "https://github.com/AdonaiVera/EgoExOR",
-    max_samples=100,
-    download_full=True,
-)
-
-fo.launch_app(dataset)
-```
-
-For full FiftyOne integration details, see [AdonaiVera/EgoExOR](https://github.com/AdonaiVera/EgoExOR).
 
 ## 🚀 Quick Start
 Get started with the dataset using the provided Python utilities. Refer to [´tutorial.ipynb´] for detailed examples.
@@ -93,6 +56,35 @@ merge_files(
     output_file="EgoExOR.h5"
 )
 ```
+
+## 🔎 Visualization (Optional)
+For interactive browsing, qualitative inspection, and debugging, the dataset can optionally be explored using external visualization frameworks such as [FiftyOne](https://docs.voxel51.com/).
+
+```bash
+pip install fiftyone h5py huggingface-hub
+```
+
+```python
+import fiftyone as fo
+import fiftyone.zoo as foz
+
+# Load dataset (downloads miss_4.h5 by default)
+dataset = foz.load_zoo_dataset(
+    "https://github.com/AdonaiVera/EgoExOR",
+    max_samples=100,
+)
+
+# Launch the FiftyOne App
+fo.launch_app(dataset)
+```
+
+The FiftyOne loader supports multiple options:
+- **Specific files**: `h5_files=["miss_1.h5", "ultrasound_1.h5"]`
+- **Local files**: `h5_path="/path/to/egoexor.h5"`
+- **Full dataset**: `download_full=True` (requires ~100GB)
+
+For full FiftyOne integration details, see [AdonaiVera/EgoExOR](https://github.com/AdonaiVera/EgoExOR).
+
 
 ## 📂 Dataset Structure
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,4 @@ flash-attn==2.3.4
 torchinfo==1.8.0
 wandb==0.19.11
 numpy==1.26.4
-fiftyone==1.10.0
 # pip install -e . in LLaVA to install it locally, editable


### PR DESCRIPTION
This PR incorporates the documentation contribution proposed in the external pull request
https://github.com/ardamamur/EgoExOR/pull/3, with minor wording refinements to keep the README consistent and dataset-centric.

External visualization tools are presented as optional utilities rather than primary entry points.
No dataset content or code is modified.